### PR TITLE
fix do not stop query on aqlEdgeNode

### DIFF
--- a/src/__tests__/queryTranslation.test.ts
+++ b/src/__tests__/queryTranslation.test.ts
@@ -123,28 +123,28 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          name: user.name,
-          bio: user.bio,
-          id: user._key
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                name: user.name,
+                bio: user.bio,
+                id: user._key
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+            }
+        `);
   });
 
   test('translates a document with a nested node', async () => {
@@ -185,37 +185,37 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          name: user.name,
-          id: user._key,
-          simplePosts: (
-            FOR user_simplePosts IN OUTBOUND user posted
-            RETURN {
-              _id: user_simplePosts._id,
-              _key: user_simplePosts._key,
-              _rev: user_simplePosts._rev,
-              title: user_simplePosts.title,
-              id: user_simplePosts._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                name: user.name,
+                id: user._key,
+                simplePosts: (
+                  FOR user_simplePosts IN OUTBOUND user posted
+                  RETURN {
+                    _id: user_simplePosts._id,
+                    _key: user_simplePosts._key,
+                    _rev: user_simplePosts._rev,
+                    title: user_simplePosts.title,
+                    id: user_simplePosts._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+            }
+        `);
   });
 
   test('filters', async () => {
@@ -246,42 +246,42 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          id: user._key,
-          filteredPosts: (
-            FOR user_filteredPosts IN OUTBOUND user posted
-              FILTER user_filteredPosts.title =~ @field_user_filteredPosts.args.titleMatch
-            RETURN {
-              _id: user_filteredPosts._id,
-              _key: user_filteredPosts._key,
-              _rev: user_filteredPosts._rev,
-              title: user_filteredPosts.title,
-              id: user_filteredPosts._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                id: user._key,
+                filteredPosts: (
+                  FOR user_filteredPosts IN OUTBOUND user posted
+                    FILTER user_filteredPosts.title =~ @field_user_filteredPosts.args.titleMatch
+                  RETURN {
+                    _id: user_filteredPosts._id,
+                    _key: user_filteredPosts._key,
+                    _rev: user_filteredPosts._rev,
+                    title: user_filteredPosts.title,
+                    id: user_filteredPosts._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-        "field_user_filteredPosts": Object {
-          "args": Object {
-            "titleMatch": "here",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+              "field_user_filteredPosts": Object {
+                "args": Object {
+                  "titleMatch": "here",
+                },
+              },
+            }
+        `);
   });
 
   test('paginates', async () => {
@@ -316,45 +316,45 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          id: user._key,
-          paginatedPosts: (
-            FOR user_paginatedPosts IN OUTBOUND user posted
-              SORT user_paginatedPosts[@field_user_paginatedPosts.args.sort] ASC
-              LIMIT @field_user_paginatedPosts.args.skip @field_user_paginatedPosts.args.count
-            RETURN {
-              _id: user_paginatedPosts._id,
-              _key: user_paginatedPosts._key,
-              _rev: user_paginatedPosts._rev,
-              title: user_paginatedPosts.title,
-              id: user_paginatedPosts._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                id: user._key,
+                paginatedPosts: (
+                  FOR user_paginatedPosts IN OUTBOUND user posted
+                    SORT user_paginatedPosts[@field_user_paginatedPosts.args.sort] ASC
+                    LIMIT @field_user_paginatedPosts.args.skip @field_user_paginatedPosts.args.count
+                  RETURN {
+                    _id: user_paginatedPosts._id,
+                    _key: user_paginatedPosts._key,
+                    _rev: user_paginatedPosts._rev,
+                    title: user_paginatedPosts.title,
+                    id: user_paginatedPosts._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-        "field_user_paginatedPosts": Object {
-          "args": Object {
-            "count": 2,
-            "skip": 0,
-            "sort": "title",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+              "field_user_paginatedPosts": Object {
+                "args": Object {
+                  "count": 2,
+                  "skip": 0,
+                  "sort": "title",
+                },
+              },
+            }
+        `);
   });
 
   test('sorts descending', async () => {
@@ -389,37 +389,37 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          id: user._key,
-          descendingPosts: (
-            FOR user_descendingPosts IN OUTBOUND user posted
-              SORT user_descendingPosts[\\"title\\"] DESC
-            RETURN {
-              _id: user_descendingPosts._id,
-              _key: user_descendingPosts._key,
-              _rev: user_descendingPosts._rev,
-              title: user_descendingPosts.title,
-              id: user_descendingPosts._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                id: user._key,
+                descendingPosts: (
+                  FOR user_descendingPosts IN OUTBOUND user posted
+                    SORT user_descendingPosts[\\"title\\"] DESC
+                  RETURN {
+                    _id: user_descendingPosts._id,
+                    _key: user_descendingPosts._key,
+                    _rev: user_descendingPosts._rev,
+                    title: user_descendingPosts.title,
+                    id: user_descendingPosts._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+            }
+        `);
   });
 
   test('traverses edges', async () => {
@@ -474,7 +474,16 @@ describe('query translation integration tests', () => {
               _key: user_friends._key,
               _rev: user_friends._rev,
               strength: user_friends.strength,
-              user: user_friends_node
+              user: FIRST(
+                LET user_friends_user = user_friends_node
+                RETURN {
+                  _id: user_friends_user._id,
+                  _key: user_friends_user._key,
+                  _rev: user_friends_user._rev,
+                  name: user_friends_user.name,
+                  id: user_friends_user._key
+                }
+              )
             }
           )
         }
@@ -482,14 +491,14 @@ describe('query translation integration tests', () => {
       RETURN query"
     `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+            }
+        `);
   });
 
   test('runs arbitrary subqueries', async () => {
@@ -522,37 +531,37 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          name: user.name,
-          id: user._key,
-          friendsOfFriends: (
-            FOR user_friendsOfFriends IN 2..2 ANY user friendOf OPTIONS {bfs: true, uniqueVertices: 'path'}
-            RETURN {
-              _id: user_friendsOfFriends._id,
-              _key: user_friendsOfFriends._key,
-              _rev: user_friendsOfFriends._rev,
-              name: user_friendsOfFriends.name,
-              id: user_friendsOfFriends._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                name: user.name,
+                id: user._key,
+                friendsOfFriends: (
+                  FOR user_friendsOfFriends IN 2..2 ANY user friendOf OPTIONS {bfs: true, uniqueVertices: 'path'}
+                  RETURN {
+                    _id: user_friendsOfFriends._id,
+                    _key: user_friendsOfFriends._key,
+                    _rev: user_friendsOfFriends._rev,
+                    name: user_friendsOfFriends.name,
+                    id: user_friendsOfFriends._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+            }
+        `);
   });
 
   test('uses context values', async () => {
@@ -583,30 +592,30 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = (
-        LET authenticatedUser = DOCUMENT('users', @context.userId)
-        LET allAuthorizedPosts = UNION_DISTINCT(
-          (FOR post IN posts FILTER post.public == true RETURN post),
-          (FOR post IN OUTBOUND authenticatedUser posted RETURN post)
-        )
-        FOR authorizedPosts IN allAuthorizedPosts
-        RETURN {
-          _id: authorizedPosts._id,
-          _key: authorizedPosts._key,
-          _rev: authorizedPosts._rev,
-          title: authorizedPosts.title,
-          id: authorizedPosts._key
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = (
+              LET authenticatedUser = DOCUMENT('users', @context.userId)
+              LET allAuthorizedPosts = UNION_DISTINCT(
+                (FOR post IN posts FILTER post.public == true RETURN post),
+                (FOR post IN OUTBOUND authenticatedUser posted RETURN post)
+              )
+              FOR authorizedPosts IN allAuthorizedPosts
+              RETURN {
+                _id: authorizedPosts._id,
+                _key: authorizedPosts._key,
+                _rev: authorizedPosts._rev,
+                title: authorizedPosts.title,
+                id: authorizedPosts._key
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "context": Object {
-          "userId": "foo",
-        },
-      }
-    `);
+            Object {
+              "context": Object {
+                "userId": "foo",
+              },
+            }
+        `);
   });
 
   test('runs aql expressions', async () => {
@@ -629,27 +638,27 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          id: user._key,
-          fullName: CONCAT(user.name, \\" \\", user.surname)
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                id: user._key,
+                fullName: CONCAT(user.name, \\" \\", user.surname)
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+            }
+        `);
   });
 
   test('does a Relay-style connection', async () => {
@@ -697,93 +706,93 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          id: user._key,
-          postsConnection: FIRST(
-            LET user_postsConnection_listPlusOne = (
-              FOR user_postsConnection_node, user_postsConnection_edge IN OUTBOUND user posted
-                OPTIONS {bfs: true}
-              FILTER user_postsConnection_node && (!@field_user_postsConnection.args.after || user_postsConnection_node.title > @field_user_postsConnection.args.after) && (
-                @field_user_postsConnection.args['filter'] != null && (
-                  @field_user_postsConnection.args['filter'].publishedAfter == null || user_postsConnection_node.publishedAt > @field_user_postsConnection.args['filter'].publishedAfter
-                ) && (
-                  @field_user_postsConnection.args['filter'].titleLike == null || LIKE(user_postsConnection_node.title, CONCAT(\\"%\\", @field_user_postsConnection.args['filter'].titleLike, \\"%\\"))
-                )
-              )
-              SORT user_postsConnection_node.title ASC
-              LIMIT @field_user_postsConnection.args.first + 1
-              RETURN MERGE(user_postsConnection_edge, { cursor: user_postsConnection_node.title, node: user_postsConnection_node })
-            )
-            LET user_postsConnection_pruned_edges = SLICE(user_postsConnection_listPlusOne, 0, @field_user_postsConnection.args.first)
-            LET user_postsConnection = {
-              edges: user_postsConnection_pruned_edges,
-              pageInfo: { 
-                hasNextPage: LENGTH(user_postsConnection_listPlusOne) == @field_user_postsConnection.args.first + 1,
-                startCursor: LENGTH(user_postsConnection_pruned_edges) > 0 ? FIRST(user_postsConnection_pruned_edges).cursor : null,
-                endCursor: LENGTH(user_postsConnection_pruned_edges) > 0 ? LAST(user_postsConnection_pruned_edges).cursor : null
-              }
-            }
-            RETURN {
-              _id: user_postsConnection._id,
-              _key: user_postsConnection._key,
-              _rev: user_postsConnection._rev,
-              edges: (
-                FOR user_postsConnection_edges IN user_postsConnection.edges
-                RETURN {
-                  _id: user_postsConnection_edges._id,
-                  _key: user_postsConnection_edges._key,
-                  _rev: user_postsConnection_edges._rev,
-                  cursor: user_postsConnection_edges.cursor,
-                  node: FIRST(
-                    LET user_postsConnection_edges_node = user_postsConnection_edges.node
-                    RETURN {
-                      _id: user_postsConnection_edges_node._id,
-                      _key: user_postsConnection_edges_node._key,
-                      _rev: user_postsConnection_edges_node._rev,
-                      title: user_postsConnection_edges_node.title,
-                      id: user_postsConnection_edges_node._key
-                    }
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                id: user._key,
+                postsConnection: FIRST(
+                  LET user_postsConnection_listPlusOne = (
+                    FOR user_postsConnection_node, user_postsConnection_edge IN OUTBOUND user posted
+                      OPTIONS {bfs: true}
+                    FILTER user_postsConnection_node && (!@field_user_postsConnection.args.after || user_postsConnection_node.title > @field_user_postsConnection.args.after) && (
+                      @field_user_postsConnection.args['filter'] != null && (
+                        @field_user_postsConnection.args['filter'].publishedAfter == null || user_postsConnection_node.publishedAt > @field_user_postsConnection.args['filter'].publishedAfter
+                      ) && (
+                        @field_user_postsConnection.args['filter'].titleLike == null || LIKE(user_postsConnection_node.title, CONCAT(\\"%\\", @field_user_postsConnection.args['filter'].titleLike, \\"%\\"))
+                      )
+                    )
+                    SORT user_postsConnection_node.title ASC
+                    LIMIT @field_user_postsConnection.args.first + 1
+                    RETURN MERGE(user_postsConnection_edge, { cursor: user_postsConnection_node.title, node: user_postsConnection_node })
                   )
-                }
-              ),
-              pageInfo: FIRST(
-                LET user_postsConnection_pageInfo = user_postsConnection.pageInfo
-                RETURN {
-                  _id: user_postsConnection_pageInfo._id,
-                  _key: user_postsConnection_pageInfo._key,
-                  _rev: user_postsConnection_pageInfo._rev,
-                  hasNextPage: user_postsConnection_pageInfo.hasNextPage
-                }
-              )
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+                  LET user_postsConnection_pruned_edges = SLICE(user_postsConnection_listPlusOne, 0, @field_user_postsConnection.args.first)
+                  LET user_postsConnection = {
+                    edges: user_postsConnection_pruned_edges,
+                    pageInfo: { 
+                      hasNextPage: LENGTH(user_postsConnection_listPlusOne) == @field_user_postsConnection.args.first + 1,
+                      startCursor: LENGTH(user_postsConnection_pruned_edges) > 0 ? FIRST(user_postsConnection_pruned_edges).cursor : null,
+                      endCursor: LENGTH(user_postsConnection_pruned_edges) > 0 ? LAST(user_postsConnection_pruned_edges).cursor : null
+                    }
+                  }
+                  RETURN {
+                    _id: user_postsConnection._id,
+                    _key: user_postsConnection._key,
+                    _rev: user_postsConnection._rev,
+                    edges: (
+                      FOR user_postsConnection_edges IN user_postsConnection.edges
+                      RETURN {
+                        _id: user_postsConnection_edges._id,
+                        _key: user_postsConnection_edges._key,
+                        _rev: user_postsConnection_edges._rev,
+                        cursor: user_postsConnection_edges.cursor,
+                        node: FIRST(
+                          LET user_postsConnection_edges_node = user_postsConnection_edges.node
+                          RETURN {
+                            _id: user_postsConnection_edges_node._id,
+                            _key: user_postsConnection_edges_node._key,
+                            _rev: user_postsConnection_edges_node._rev,
+                            title: user_postsConnection_edges_node.title,
+                            id: user_postsConnection_edges_node._key
+                          }
+                        )
+                      }
+                    ),
+                    pageInfo: FIRST(
+                      LET user_postsConnection_pageInfo = user_postsConnection.pageInfo
+                      RETURN {
+                        _id: user_postsConnection_pageInfo._id,
+                        _key: user_postsConnection_pageInfo._key,
+                        _rev: user_postsConnection_pageInfo._rev,
+                        hasNextPage: user_postsConnection_pageInfo.hasNextPage
+                      }
+                    )
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-        "field_user_postsConnection": Object {
-          "args": Object {
-            "after": "opaqueCursor",
-            "filter": Object {
-              "publishedAfter": "2019-17-08 04:27:54 AM",
-            },
-            "first": 10,
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+              "field_user_postsConnection": Object {
+                "args": Object {
+                  "after": "opaqueCursor",
+                  "filter": Object {
+                    "publishedAfter": "2019-17-08 04:27:54 AM",
+                  },
+                  "first": 10,
+                },
+              },
+            }
+        `);
   });
 
   test('passes traversal options', async () => {
@@ -824,38 +833,38 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET user = DOCUMENT(users, @field_user.args.id)
-        RETURN {
-          _id: user._id,
-          _key: user._key,
-          _rev: user._rev,
-          name: user.name,
-          id: user._key,
-          bfsPosts: (
-            FOR user_bfsPosts IN OUTBOUND user posted
-              OPTIONS { bfs: true }
-            RETURN {
-              _id: user_bfsPosts._id,
-              _key: user_bfsPosts._key,
-              _rev: user_bfsPosts._rev,
-              title: user_bfsPosts.title,
-              id: user_bfsPosts._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET user = DOCUMENT(users, @field_user.args.id)
+              RETURN {
+                _id: user._id,
+                _key: user._key,
+                _rev: user._rev,
+                name: user.name,
+                id: user._key,
+                bfsPosts: (
+                  FOR user_bfsPosts IN OUTBOUND user posted
+                    OPTIONS { bfs: true }
+                  RETURN {
+                    _id: user_bfsPosts._id,
+                    _key: user_bfsPosts._key,
+                    _rev: user_bfsPosts._rev,
+                    title: user_bfsPosts.title,
+                    id: user_bfsPosts._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_user": Object {
-          "args": Object {
-            "id": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_user": Object {
+                "args": Object {
+                  "id": "foo",
+                },
+              },
+            }
+        `);
   });
 
   test('resolves a custom query inside the resolver with selections', async () => {
@@ -883,40 +892,40 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET createUser = FIRST(
-          
-                        INSERT {_key: @value0, role: @value1, name: @value2} INTO users
-                        RETURN NEW
-                      
-        )
-        RETURN {
-          _id: createUser._id,
-          _key: createUser._key,
-          _rev: createUser._rev,
-          name: createUser.name,
-          id: createUser._key,
-          simplePosts: (
-            FOR createUser_simplePosts IN OUTBOUND createUser posted
-            RETURN {
-              _id: createUser_simplePosts._id,
-              _key: createUser_simplePosts._key,
-              _rev: createUser_simplePosts._rev,
-              title: createUser_simplePosts.title,
-              id: createUser_simplePosts._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET createUser = FIRST(
+                
+                              INSERT {_key: @value0, role: @value1, name: @value2} INTO users
+                              RETURN NEW
+                            
+              )
+              RETURN {
+                _id: createUser._id,
+                _key: createUser._key,
+                _rev: createUser._rev,
+                name: createUser.name,
+                id: createUser._key,
+                simplePosts: (
+                  FOR createUser_simplePosts IN OUTBOUND createUser posted
+                  RETURN {
+                    _id: createUser_simplePosts._id,
+                    _key: createUser_simplePosts._key,
+                    _rev: createUser_simplePosts._rev,
+                    title: createUser_simplePosts.title,
+                    id: createUser_simplePosts._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "value0": "foobar",
-        "value1": "captain",
-        "value2": "Bob",
-      }
-    `);
+            Object {
+              "value0": "foobar",
+              "value1": "captain",
+              "value2": "Bob",
+            }
+        `);
   });
 
   test('resolves a custom builder-based query with conditional behavior', async () => {
@@ -954,59 +963,59 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET posts_listPlusOne = (
-          FOR posts_node IN SearchView SEARCH PHRASE(posts_node.name, @field_posts.args.searchTerm, 'text_en')
-          FILTER (!@field_posts.args.after || BM25(posts_node) > @field_posts.args.after) && true
-          SORT BM25(posts_node) DESC
-          LIMIT @field_posts.args.first + 1
-          RETURN { cursor: BM25(posts_node), node: posts_node }
-        )
-        LET posts_pruned_edges = SLICE(posts_listPlusOne, 0, @field_posts.args.first)
-        LET posts = {
-          edges: posts_pruned_edges,
-          pageInfo: { 
-            hasNextPage: LENGTH(posts_listPlusOne) == @field_posts.args.first + 1,
-            startCursor: LENGTH(posts_pruned_edges) > 0 ? FIRST(posts_pruned_edges).cursor : null,
-            endCursor: LENGTH(posts_pruned_edges) > 0 ? LAST(posts_pruned_edges).cursor : null
-          }
-        }
-        RETURN {
-          _id: posts._id,
-          _key: posts._key,
-          _rev: posts._rev,
-          edges: (
-            FOR posts_edges IN posts.edges
-            RETURN {
-              _id: posts_edges._id,
-              _key: posts_edges._key,
-              _rev: posts_edges._rev,
-              node: FIRST(
-                LET posts_edges_node = posts_edges.node
-                RETURN {
-                  _id: posts_edges_node._id,
-                  _key: posts_edges_node._key,
-                  _rev: posts_edges_node._rev,
-                  title: posts_edges_node.title,
-                  id: posts_edges_node._key
-                }
+            "LET query = FIRST(
+              LET posts_listPlusOne = (
+                FOR posts_node IN SearchView SEARCH PHRASE(posts_node.name, @field_posts.args.searchTerm, 'text_en')
+                FILTER (!@field_posts.args.after || BM25(posts_node) > @field_posts.args.after) && true
+                SORT BM25(posts_node) DESC
+                LIMIT @field_posts.args.first + 1
+                RETURN { cursor: BM25(posts_node), node: posts_node }
               )
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+              LET posts_pruned_edges = SLICE(posts_listPlusOne, 0, @field_posts.args.first)
+              LET posts = {
+                edges: posts_pruned_edges,
+                pageInfo: { 
+                  hasNextPage: LENGTH(posts_listPlusOne) == @field_posts.args.first + 1,
+                  startCursor: LENGTH(posts_pruned_edges) > 0 ? FIRST(posts_pruned_edges).cursor : null,
+                  endCursor: LENGTH(posts_pruned_edges) > 0 ? LAST(posts_pruned_edges).cursor : null
+                }
+              }
+              RETURN {
+                _id: posts._id,
+                _key: posts._key,
+                _rev: posts._rev,
+                edges: (
+                  FOR posts_edges IN posts.edges
+                  RETURN {
+                    _id: posts_edges._id,
+                    _key: posts_edges._key,
+                    _rev: posts_edges._rev,
+                    node: FIRST(
+                      LET posts_edges_node = posts_edges.node
+                      RETURN {
+                        _id: posts_edges_node._id,
+                        _key: posts_edges_node._key,
+                        _rev: posts_edges_node._rev,
+                        title: posts_edges_node.title,
+                        id: posts_edges_node._key
+                      }
+                    )
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_posts": Object {
-          "args": Object {
-            "first": 10,
-            "searchTerm": "foo",
-          },
-        },
-      }
-    `);
+            Object {
+              "field_posts": Object {
+                "args": Object {
+                  "first": 10,
+                  "searchTerm": "foo",
+                },
+              },
+            }
+        `);
 
     await run(
       `
@@ -1042,58 +1051,58 @@ describe('query translation integration tests', () => {
     );
 
     expect(mockRunQuery.mock.calls[1][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET posts_listPlusOne = (
-          FOR posts_node IN posts
-          FILTER (!@field_posts.args.after || posts_node.createdAt > @field_posts.args.after) && true
-          SORT posts_node.createdAt ASC
-          LIMIT @field_posts.args.first + 1
-          RETURN { cursor: posts_node.createdAt, node: posts_node }
-        )
-        LET posts_pruned_edges = SLICE(posts_listPlusOne, 0, @field_posts.args.first)
-        LET posts = {
-          edges: posts_pruned_edges,
-          pageInfo: { 
-            hasNextPage: LENGTH(posts_listPlusOne) == @field_posts.args.first + 1,
-            startCursor: LENGTH(posts_pruned_edges) > 0 ? FIRST(posts_pruned_edges).cursor : null,
-            endCursor: LENGTH(posts_pruned_edges) > 0 ? LAST(posts_pruned_edges).cursor : null
-          }
-        }
-        RETURN {
-          _id: posts._id,
-          _key: posts._key,
-          _rev: posts._rev,
-          edges: (
-            FOR posts_edges IN posts.edges
-            RETURN {
-              _id: posts_edges._id,
-              _key: posts_edges._key,
-              _rev: posts_edges._rev,
-              node: FIRST(
-                LET posts_edges_node = posts_edges.node
-                RETURN {
-                  _id: posts_edges_node._id,
-                  _key: posts_edges_node._key,
-                  _rev: posts_edges_node._rev,
-                  title: posts_edges_node.title,
-                  id: posts_edges_node._key
-                }
+            "LET query = FIRST(
+              LET posts_listPlusOne = (
+                FOR posts_node IN posts
+                FILTER (!@field_posts.args.after || posts_node.createdAt > @field_posts.args.after) && true
+                SORT posts_node.createdAt ASC
+                LIMIT @field_posts.args.first + 1
+                RETURN { cursor: posts_node.createdAt, node: posts_node }
               )
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+              LET posts_pruned_edges = SLICE(posts_listPlusOne, 0, @field_posts.args.first)
+              LET posts = {
+                edges: posts_pruned_edges,
+                pageInfo: { 
+                  hasNextPage: LENGTH(posts_listPlusOne) == @field_posts.args.first + 1,
+                  startCursor: LENGTH(posts_pruned_edges) > 0 ? FIRST(posts_pruned_edges).cursor : null,
+                  endCursor: LENGTH(posts_pruned_edges) > 0 ? LAST(posts_pruned_edges).cursor : null
+                }
+              }
+              RETURN {
+                _id: posts._id,
+                _key: posts._key,
+                _rev: posts._rev,
+                edges: (
+                  FOR posts_edges IN posts.edges
+                  RETURN {
+                    _id: posts_edges._id,
+                    _key: posts_edges._key,
+                    _rev: posts_edges._rev,
+                    node: FIRST(
+                      LET posts_edges_node = posts_edges.node
+                      RETURN {
+                        _id: posts_edges_node._id,
+                        _key: posts_edges_node._key,
+                        _rev: posts_edges_node._rev,
+                        title: posts_edges_node.title,
+                        id: posts_edges_node._key
+                      }
+                    )
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[1][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "field_posts": Object {
-          "args": Object {
-            "first": 10,
-          },
-        },
-      }
-    `);
+            Object {
+              "field_posts": Object {
+                "args": Object {
+                  "first": 10,
+                },
+              },
+            }
+        `);
   });
 
   test('resolves multi-query operations to avoid read-after-write errors', async () => {
@@ -1139,54 +1148,54 @@ describe('query translation integration tests', () => {
 
     expect(mockRunQuery).toHaveBeenCalledTimes(2);
     expect(mockRunQuery.mock.calls[0][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        INSERT { title: \\"Fake post\\", body: \\"foo\\", publishedAt: \\"2019-05-03\\" }
-        INTO posts
-        OPTIONS { waitForSync: true }
-        LET createPost = {
-          post: NEW
-        }
-        RETURN {
-          _id: createPost._id,
-          _key: createPost._key,
-          _rev: createPost._rev,
-          post: createPost.post
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              INSERT { title: \\"Fake post\\", body: \\"foo\\", publishedAt: \\"2019-05-03\\" }
+              INTO posts
+              OPTIONS { waitForSync: true }
+              LET createPost = {
+                post: NEW
+              }
+              RETURN {
+                _id: createPost._id,
+                _key: createPost._key,
+                _rev: createPost._rev,
+                post: createPost.post
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[0][0].bindVars).toMatchInlineSnapshot(
       `Object {}`
     );
     expect(mockRunQuery.mock.calls[1][0].query).toMatchInlineSnapshot(`
-      "LET query = FIRST(
-        LET post = DOCUMENT(posts, @parent._key)
-        RETURN {
-          _id: post._id,
-          _key: post._key,
-          _rev: post._rev,
-          title: post.title,
-          id: post._key,
-          author: FIRST(
-            FOR post_author IN INBOUND post posted
-              LIMIT 1
-            RETURN {
-              _id: post_author._id,
-              _key: post_author._key,
-              _rev: post_author._rev,
-              id: post_author._key
-            }
-          )
-        }
-      )
-      RETURN query"
-    `);
+            "LET query = FIRST(
+              LET post = DOCUMENT(posts, @parent._key)
+              RETURN {
+                _id: post._id,
+                _key: post._key,
+                _rev: post._rev,
+                title: post.title,
+                id: post._key,
+                author: FIRST(
+                  FOR post_author IN INBOUND post posted
+                    LIMIT 1
+                  RETURN {
+                    _id: post_author._id,
+                    _key: post_author._key,
+                    _rev: post_author._rev,
+                    id: post_author._key
+                  }
+                )
+              }
+            )
+            RETURN query"
+        `);
     expect(mockRunQuery.mock.calls[1][0].bindVars).toMatchInlineSnapshot(`
-      Object {
-        "parent": Object {
-          "postId": "3",
-        },
-      }
-    `);
+            Object {
+              "parent": Object {
+                "postId": "3",
+              },
+            }
+        `);
   });
 });

--- a/src/builders/aqlEdgeNode.ts
+++ b/src/builders/aqlEdgeNode.ts
@@ -1,9 +1,14 @@
 import { Builder } from '../types';
+import { lines } from '../utils/strings';
+import { buildSubquery } from '../utils/aql';
 
 export const aqlEdgeNode: Builder = {
   name: 'aqlEdgeNode',
-  build: ({ parentName }) => {
+  build: ({ parentName, returnsList, children }) => {
     // this is assuming we are in the scope of a parent @edge subquery
-    return `${parentName}_node`;
+    return buildSubquery(
+      lines([`LET $field = ${parentName}_node`, children()]),
+      returnsList
+    );
   },
 };


### PR DESCRIPTION
Hi @a-type,

Thank you for this experimental library which allows to do prototyping very quickly and is mostly stable for some little projects.

I noticed a limitation which can be improved: When using `@aqlEdge` and `@aqlEdgeNode` directives, the query stops on `@aqlEdgeNode` and return the whole object.

# Exemple

## Schema

```graphql
type Entity {
    _key: ID!
    name: String!

    groups: [EntityGroupOutboundEdge!]!
        @aqlEdge(
            collection: "EntityGroups"
            direction: OUTBOUND
        )
}

type Group {
    _key: ID!
    name: String!

    categoryKey: ID!
    category: GroupCategory!
        @aqlDocument(
            collection: "Categories"
            key: "$parent.categoryKey"
        )

    entities: [EntityGroupInboundEdge!]!
        @aqlEdge(
            collection: "EntityGroups"
            direction: INBOUND
        )
}

type GroupCategory {
    _key: ID!
    name: String!

    groups: [Group!]!
        @aqlDocument(
            collection: "Groups"
            filter: "$field.categoryKey == $parent._key"
        )
}

type EntityGroupOutboundEdge {
    _key: ID!
    strength: Int!

    group: Group! @aqlEdgeNode
}

type EntityGroupInboundEdge {
    _key: ID!
    strength: Int!

    entity: Entity! @aqlEdgeNode
}
```

## Query

```graphql
query GetEntityWithGroupsAndCategories($entityKey: ID!) {
    getEntity(key: $entityKey) {
        name
        groups {
            strength
            group {
                name
                category {
                    name
                }
            }
        }
    }
}
```

## Error

`Error: Cannot return null for non-nullable field Group.category.`

# Workaround

Run a subquery to allow children traversal in `@aqlEdgeNode`